### PR TITLE
Removed tensorflow-base from the dependency list

### DIFF
--- a/tensorflow-serving-api/meta.yaml
+++ b/tensorflow-serving-api/meta.yaml
@@ -21,12 +21,11 @@ requirements:
   host:
    - bazel {{ bazel }}
    - python # noarch package; don't tie to specific python version
-   - tensorflow-base {{ tensorflow }}
+   - numpy {{ numpy }}
    - grpcio {{ grpcio }}
    - protobuf {{ protobuf }}
   run:
    - python # noarch package; don't tie to specific python version
-   - tensorflow-base >={{ tensorflow }}
    - grpcio {{ grpcio }}
    - protobuf {{ protobuf }}
 

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -27,7 +27,6 @@ requirements:
   host:
    - libevent {{ libevent }}
    - bazel {{ bazel }}
-   - tensorflow-base {{ tensorflow }} {{ build_type }}* 
    - cudatoolkit-dev {{ cudatoolkit }} # [build_type == 'cuda']
    - cudnn {{ cudnn }}                 # [build_type == 'cuda']
    - nccl {{ nccl }}                   # [build_type == 'cuda']


### PR DESCRIPTION
Removed tensorflow-base from the dependency list of tensorflow-serving and tensorflow-serving-api. I verified it on x86 and the basic test has passed. On ppc64le, could not verify due to `python: Invalid argument issue`.