### PR TITLE
Adding numpy dependency

### DIFF
--- a/tensorflow-serving-api/build.sh
+++ b/tensorflow-serving-api/build.sh
@@ -16,6 +16,9 @@ if [[ "${ARCH}" == 'ppc64le' ]]; then
     export CC_OPT_FLAGS="-mcpu=power8 -mtune=power8"
 fi
 
+bazel clean --expunge
+bazel shutdown
+
 bazel build \
     --color=yes \
     --curses=yes \

--- a/tensorflow-serving/build.sh
+++ b/tensorflow-serving/build.sh
@@ -44,6 +44,9 @@ fi
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PREFIX}/lib
 
+bazel clean --expunge
+bazel shutdown
+
 bazel build ${BUILD_OPTS} \
     --action_env PYTHON_BIN_PATH="$PYTHON" \
     --action_env PYTHON_LIB_PATH="$SP_DIR" \

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -31,6 +31,7 @@ requirements:
    - cudnn {{ cudnn }}                 # [build_type == 'cuda']
    - nccl {{ nccl }}                   # [build_type == 'cuda']
    - tensorrt {{ tensorrt }}           # [build_type == 'cuda']
+   - numpy {{ numpy }}
    - grpcio {{ grpcio }}
    - python {{ python }}
   run:


### PR DESCRIPTION
Since we removed tensorflow-base from the dependency, there is no way that numpy can be brought into the build. So, we need to explicitly add it as a dependency here. I'd added it for serving-api in my earlier PR. 
TF serving had passed for me without it earlier, may be because of bazel cache had it when serving was built with tensorflow-base.