### PR TITLE
Fixed the build on x86 RH8 baremetal

### DIFF
--- a/tensorflow-serving/0000-tensorflow_patches.patch
+++ b/tensorflow-serving/0000-tensorflow_patches.patch
@@ -1,18 +1,18 @@
-From 2e98243c5c9e77fe6bc61ef8db76ac3f676ff9f2 Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepali@us.ibm.com>
-Date: Fri, 18 Dec 2020 05:44:28 +0000
+From 8f4ca4817835616e52c6be5037c34c6bc1a6dd95 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Tue, 5 Jan 2021 08:20:02 +0000
 Subject: [PATCH] Patches for TF 2.4
 
 ---
- WORKSPACE                                       |   1 +
- third_party/tensorflow/BUILD                    |   0
- third_party/tensorflow/tensorflow_patches.patch | 182 ++++++++++++++++++++++++
- 3 files changed, 183 insertions(+)
+ WORKSPACE                                     |   1 +
+ third_party/tensorflow/BUILD                  |   0
+ .../tensorflow/tensorflow_patches.patch       | 196 ++++++++++++++++++
+ 3 files changed, 197 insertions(+)
  create mode 100644 third_party/tensorflow/BUILD
  create mode 100644 third_party/tensorflow/tensorflow_patches.patch
 
 diff --git a/WORKSPACE b/WORKSPACE
-index 54d52e2..14a435e 100644
+index 54d52e25..14a435e9 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
 @@ -13,6 +13,7 @@ tensorflow_http_archive(
@@ -25,28 +25,42 @@ index 54d52e2..14a435e 100644
  load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 diff --git a/third_party/tensorflow/BUILD b/third_party/tensorflow/BUILD
 new file mode 100644
-index 0000000..e69de29
+index 00000000..e69de29b
 diff --git a/third_party/tensorflow/tensorflow_patches.patch b/third_party/tensorflow/tensorflow_patches.patch
 new file mode 100644
-index 0000000..0707494
+index 00000000..8033aca8
 --- /dev/null
 +++ b/third_party/tensorflow/tensorflow_patches.patch
-@@ -0,0 +1,182 @@
-+From 4bc378807dc11e444e4d00ce2a94b0fbe709f5d3 Mon Sep 17 00:00:00 2001
-+From: Deepali Chourasia <deepali@us.ibm.com>
-+Date: Fri, 18 Dec 2020 05:43:20 +0000
+@@ -0,0 +1,196 @@
++From aea0f0147936e79981c59bebcb939145c8b0cade Mon Sep 17 00:00:00 2001
++From: Nishidha Panpaliya <npanpa23@in.ibm.com>
++Date: Tue, 5 Jan 2021 08:18:53 +0000
 +Subject: [PATCH] TF 2.4 patches
 +
 +---
-+ tensorflow/tensorflow.bzl                          |  4 +-
-+ .../com_google_absl_fix_mac_and_nvcc_build.patch   | 45 +++++++++++++---------
-+ third_party/gpus/find_cuda_config.py               |  2 +
-+ third_party/tensorrt/BUILD.tpl                     |  1 +
-+ third_party/tensorrt/tensorrt_configure.bzl        |  2 +
-+ 5 files changed, 35 insertions(+), 19 deletions(-)
++ tensorflow/stream_executor/cuda/BUILD         |  2 +-
++ tensorflow/tensorflow.bzl                     |  4 +-
++ ...m_google_absl_fix_mac_and_nvcc_build.patch | 45 +++++++++++--------
++ third_party/gpus/find_cuda_config.py          |  2 +
++ third_party/tensorrt/BUILD.tpl                |  1 +
++ third_party/tensorrt/tensorrt_configure.bzl   |  2 +
++ 6 files changed, 36 insertions(+), 20 deletions(-)
 +
++diff --git a/tensorflow/stream_executor/cuda/BUILD b/tensorflow/stream_executor/cuda/BUILD
++index 7086217fa8e..9cdd1eedb77 100644
++--- a/tensorflow/stream_executor/cuda/BUILD
+++++ b/tensorflow/stream_executor/cuda/BUILD
++@@ -271,7 +271,7 @@ alias(
++     name = "cublas_lt_lib",
++     actual = select({
++         "//tensorflow:oss": ":cublas_lt_stub",
++-        "//conditions:default": ":empty_lib",
+++        "//conditions:default": "@local_config_cuda//cuda:cublasLt",
++     }),
++     visibility = ["//visibility:public"],
++ )
 +diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
-+index 096cdd1..a93cc16 100644
++index 096cdd17dcb..a93cc168830 100644
 +--- a/tensorflow/tensorflow.bzl
 ++++ b/tensorflow/tensorflow.bzl
 +@@ -335,7 +335,7 @@ def tf_copts(
@@ -75,7 +89,7 @@ index 0000000..0707494
 +         visibility = [clean_dep("//tensorflow:internal")],
 +         compatible_with = compatible_with,
 +diff --git a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
-+index 6301119..9a7bd8b 100644
++index 6301119ab2c..9a7bd8b4b20 100644
 +--- a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
 ++++ b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
 +@@ -1,7 +1,6 @@
@@ -174,7 +188,7 @@ index 0000000..0707494
 ++ #define CONSTEXPR_F constexpr  // function
 ++ #define CONSTEXPR_M constexpr  // member
 +diff --git a/third_party/gpus/find_cuda_config.py b/third_party/gpus/find_cuda_config.py
-+index 80f3430..6a85107 100644
++index 80f343023cd..6a85107a65c 100644
 +--- a/third_party/gpus/find_cuda_config.py
 ++++ b/third_party/gpus/find_cuda_config.py
 +@@ -587,6 +587,8 @@ def find_cuda_config():
@@ -187,7 +201,7 @@ index 0000000..0707494
 +     result.update(
 +         _find_cublas_config(cublas_paths, cublas_version, cuda_version))
 +diff --git a/third_party/tensorrt/BUILD.tpl b/third_party/tensorrt/BUILD.tpl
-+index dfa06ce..0b386f9 100644
++index dfa06ced2ed..0b386f93db4 100644
 +--- a/third_party/tensorrt/BUILD.tpl
 ++++ b/third_party/tensorrt/BUILD.tpl
 +@@ -25,6 +25,7 @@ cc_library(
@@ -199,7 +213,7 @@ index 0000000..0707494
 +     deps = [
 +         ":tensorrt_headers",
 +diff --git a/third_party/tensorrt/tensorrt_configure.bzl b/third_party/tensorrt/tensorrt_configure.bzl
-+index 9c980a9..deafd2a 100644
++index 9c980a92cf8..deafd2a5a8a 100644
 +--- a/third_party/tensorrt/tensorrt_configure.bzl
 ++++ b/third_party/tensorrt/tensorrt_configure.bzl
 +@@ -101,6 +101,8 @@ def _create_local_tensorrt_repository(repository_ctx):
@@ -212,8 +226,8 @@ index 0000000..0707494
 +     headers = _get_tensorrt_headers(trt_version)
 +     include_dir = config["tensorrt_include_dir"] + "/"
 +-- 
-+1.8.3.1
++2.27.0
 +
 -- 
-1.8.3.1
+2.27.0
 

--- a/tensorflow-serving/0000-tensorflow_patches.patch
+++ b/tensorflow-serving/0000-tensorflow_patches.patch
@@ -1,13 +1,13 @@
-From 606c027615250dde0f0e725801f6e67bb1356ad3 Mon Sep 17 00:00:00 2001
+From 95ff07b2748525b6c3aaa0991aaed248814798d7 Mon Sep 17 00:00:00 2001
 From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Thu, 7 Jan 2021 07:12:21 -0500
+Date: Thu, 7 Jan 2021 08:52:46 -0500
 Subject: [PATCH] Patches for TF 2.4
 
 ---
  WORKSPACE                                     |   1 +
  third_party/tensorflow/BUILD                  |   0
- .../tensorflow/tensorflow_patches.patch       | 305 ++++++++++++++++++
- 3 files changed, 306 insertions(+)
+ .../tensorflow/tensorflow_patches.patch       | 293 ++++++++++++++++++
+ 3 files changed, 294 insertions(+)
  create mode 100644 third_party/tensorflow/BUILD
  create mode 100644 third_party/tensorflow/tensorflow_patches.patch
 
@@ -28,13 +28,13 @@ new file mode 100644
 index 00000000..e69de29b
 diff --git a/third_party/tensorflow/tensorflow_patches.patch b/third_party/tensorflow/tensorflow_patches.patch
 new file mode 100644
-index 00000000..9bfc1155
+index 00000000..b4ad792a
 --- /dev/null
 +++ b/third_party/tensorflow/tensorflow_patches.patch
-@@ -0,0 +1,305 @@
-+From 69d042292e28375ec6189aa30925475a40b7443e Mon Sep 17 00:00:00 2001
+@@ -0,0 +1,293 @@
++From f31d6a6ad09757250f88f331003c07034bc7e019 Mon Sep 17 00:00:00 2001
 +From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-+Date: Thu, 7 Jan 2021 07:11:38 -0500
++Date: Thu, 7 Jan 2021 08:47:01 -0500
 +Subject: [PATCH] TF 2.4 patches
 +
 +---
@@ -43,25 +43,25 @@ index 00000000..9bfc1155
 + tensorflow/tensorflow.bzl                     |  4 +-
 + ...m_google_absl_fix_mac_and_nvcc_build.patch | 45 +++++++++++--------
 + third_party/gpus/cuda/BUILD.tpl               |  8 ++++
-+ third_party/gpus/cuda_configure.bzl           | 17 ++++++-
++ third_party/gpus/cuda_configure.bzl           | 12 +++++
 + third_party/gpus/find_cuda_config.py          |  2 +
 + third_party/tensorrt/BUILD.tpl                |  1 +
 + third_party/tensorrt/tensorrt_configure.bzl   |  2 +
-+ 9 files changed, 64 insertions(+), 21 deletions(-)
++ 9 files changed, 60 insertions(+), 20 deletions(-)
 +
 +diff --git a/tensorflow/core/platform/default/build_config/BUILD b/tensorflow/core/platform/default/build_config/BUILD
-+index 83eadf2c460..c6e4621c0a7 100644
++index 83eadf2c460..b17542c0fc6 100644
 +--- a/tensorflow/core/platform/default/build_config/BUILD
 ++++ b/tensorflow/core/platform/default/build_config/BUILD
 +@@ -199,8 +199,12 @@ cc_library(
 +             "-Wl,-rpath,../local_config_cuda/cuda/extras/CUPTI/lib",
 +         ],
 +         "//conditions:default": [
-++	    "-lmemcpy-2.14",
-++	    "-Lbazel-out/host/bin/external/local_config_cuda/cuda/cuda/lib",
+++            "-lmemcpy-2.14",
+++            "-Lbazel-out/host/bin/external/local_config_cuda/cuda/cuda/lib",
 +             "-Wl,-rpath,../local_config_cuda/cuda/lib64",
 +             "-Wl,-rpath,../local_config_cuda/cuda/extras/CUPTI/lib64",
-++	    "-Wl,-rpath,bazel-out/host/bin/external/local_config_cuda/cuda/cuda/lib",
+++            "-Wl,-rpath,bazel-out/host/bin/external/local_config_cuda/cuda/cuda/lib",
 ++
 +         ],
 +     }),
@@ -234,7 +234,7 @@ index 00000000..9bfc1155
 + )
 + 
 +diff --git a/third_party/gpus/cuda_configure.bzl b/third_party/gpus/cuda_configure.bzl
-+index 3ba34470b93..773ab266ef7 100644
++index 3ba34470b93..f29b2d13e41 100644
 +--- a/third_party/gpus/cuda_configure.bzl
 ++++ b/third_party/gpus/cuda_configure.bzl
 +@@ -476,6 +476,8 @@ def _lib_path(lib, cpu_value, basedir, version, static):
@@ -246,17 +246,7 @@ index 00000000..9bfc1155
 +     return version and not static
 + 
 + def _check_cuda_lib_params(lib, cpu_value, basedir, version, static = False):
-+@@ -498,6 +500,9 @@ def _check_cuda_libs(repository_ctx, script_path, libs):
-+     cmd += "system('%s script.py %s');" % (python_bin, args)
-+ 
-+     all_paths = [path for path, _ in libs]
-++    print("cmd to be executed: ", cmd)
-++    print("All paths: ", all_paths)
-++    print("Script path: ", script_path)
-+     checked_paths = execute(repository_ctx, [python_bin, "-c", cmd]).stdout.splitlines()
-+ 
-+     # Filter out empty lines from splitting on '\r\n' on Windows
-+@@ -586,6 +591,13 @@ def _find_libs(repository_ctx, check_cuda_libs_script, cuda_config):
++@@ -586,6 +588,13 @@ def _find_libs(repository_ctx, check_cuda_libs_script, cuda_config):
 +             cuda_config.cudnn_version,
 +             static = False,
 +         ),
@@ -270,29 +260,27 @@ index 00000000..9bfc1155
 +         "cupti": _check_cuda_lib_params(
 +             "cupti",
 +             cpu_value,
-+@@ -794,6 +806,7 @@ def _create_dummy_repository(repository_ctx):
++@@ -794,6 +803,7 @@ def _create_dummy_repository(repository_ctx):
 +             "%{curand_lib}": lib_name("curand", cpu_value),
 +             "%{cupti_lib}": lib_name("cupti", cpu_value),
 +             "%{cusparse_lib}": lib_name("cusparse", cpu_value),
-++	    "%{memcpy-2.14_lib}": lib_name("memcpy-2.14", cpu_value),
+++            "%{memcpy-2.14_lib}": lib_name("memcpy-2.14", cpu_value),
 +             "%{cub_actual}": ":cuda_headers",
 +             "%{copy_rules}": """
 + filegroup(name="cuda-include")
-+@@ -826,7 +839,8 @@ filegroup(name="cudnn-include")
++@@ -826,6 +836,7 @@ filegroup(name="cudnn-include")
 +     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cufft", cpu_value))
 +     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cupti", cpu_value))
 +     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cusparse", cpu_value))
-+-
 ++    repository_ctx.file("cuda/cuda/lib/%s" % lib_name("memcpy-2.14", cpu_value))
-++    
++
 +     # Set up cuda_config.h, which is used by
 +     # tensorflow/stream_executor/dso_loader.cc.
-+     _tpl(
-+@@ -1165,6 +1179,7 @@ def _create_local_cuda_repository(repository_ctx):
++@@ -1165,6 +1176,7 @@ def _create_local_cuda_repository(repository_ctx):
 +             "%{curand_lib}": _basename(repository_ctx, cuda_libs["curand"]),
 +             "%{cupti_lib}": _basename(repository_ctx, cuda_libs["cupti"]),
 +             "%{cusparse_lib}": _basename(repository_ctx, cuda_libs["cusparse"]),
-++	    "%{memcpy-2.14_lib}": _basename(repository_ctx, cuda_libs["memcpy-2.14"]),
+++            "%{memcpy-2.14_lib}": _basename(repository_ctx, cuda_libs["memcpy-2.14"]),
 +             "%{cub_actual}": cub_actual,
 +             "%{copy_rules}": "\n".join(copy_rules),
 +         },

--- a/tensorflow-serving/build.sh
+++ b/tensorflow-serving/build.sh
@@ -20,6 +20,9 @@ if [[ $build_type == "cuda" ]]
 then
   # Pick up the CUDA and CUDNN environment
   $SCRIPT_DIR/set_tf_serving_nvidia_bazelrc.sh $SRC_DIR/tensorflow_serving $PY_VER
+
+  # Create symlink of libmemcpy-2.14.so from where it can be picked up by TF build
+  ln -s ${PREFIX}/lib/libmemcpy-2.14.so ${PREFIX}/lib64/libmemcpy-2.14.so
 fi
 
 # Build the bazelrc
@@ -39,7 +42,6 @@ if [ "${build_type}" = "mkl" ]; then
 fi
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PREFIX}/lib
-ln -s ${PREFIX}/lib/libmemcpy-2.14.so ${PREFIX}/lib64/libmemcpy-2.14.so
 bazel clean --expunge
 bazel shutdown
 

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -29,6 +29,7 @@ requirements:
    - make
    - libgcc                 # [x86_64 and build_type == 'cuda']
    - git >={{ git }}
+   - patch
   host:
    - libevent {{ libevent }}
    - bazel {{ bazel }}

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -12,7 +12,7 @@ source:
      - 0001-TF-Build-fix-ppc64le.patch       # [ppc64le]
  
 build:
-  number: 2
+  number: 3
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} # [build_type == 'cpu'] 
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} # [build_type == 'cuda']
 {% if build_type == 'cuda' %}
@@ -28,7 +28,7 @@ requirements:
    - libtool
    - make
    - libgcc                 # [x86_64 and build_type == 'cuda']
-   - git >=2.2
+   - git >={{ git }}
   host:
    - libevent {{ libevent }}
    - bazel {{ bazel }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes build error which is specific to x86 RH8 baremetal ( build worked fine on RH7 baremetal/container and RH8 container without any issue even without this PR). 
The same fix was done for ppc too. So, updates the x86 specific patch with the same code change. 
@cdeepali noticed another memcpy related error on RH8 x86 baremetal with this PR. So, she will be pushing the fix for it in this PR.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
