### PR TITLE
Memcpy fix

### DIFF
--- a/tensorflow-serving/0000a-tensorflow_patches.patch
+++ b/tensorflow-serving/0000a-tensorflow_patches.patch
@@ -1,18 +1,18 @@
-From 95ff07b2748525b6c3aaa0991aaed248814798d7 Mon Sep 17 00:00:00 2001
-From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Thu, 7 Jan 2021 08:52:46 -0500
-Subject: [PATCH] Patches for TF 2.4
+From 10833296ed4526722f0edb0762ce0e9ed4b6e611 Mon Sep 17 00:00:00 2001
+From: Jason Furmanek <furmanek@us.ibm.com>
+Date: Tue, 19 Jan 2021 21:24:16 +0000
+Subject: [PATCH] tensorflow patches no memcpy
 
 ---
- WORKSPACE                                     |   1 +
- third_party/tensorflow/BUILD                  |   0
- .../tensorflow/tensorflow_patches.patch       | 293 ++++++++++++++++++
- 3 files changed, 294 insertions(+)
+ WORKSPACE                                       |   1 +
+ third_party/tensorflow/BUILD                    |   0
+ third_party/tensorflow/tensorflow_patches.patch | 226 ++++++++++++++++++++++++
+ 3 files changed, 227 insertions(+)
  create mode 100644 third_party/tensorflow/BUILD
  create mode 100644 third_party/tensorflow/tensorflow_patches.patch
 
 diff --git a/WORKSPACE b/WORKSPACE
-index 54d52e25..14a435e9 100644
+index 54d52e2..14a435e 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
 @@ -13,6 +13,7 @@ tensorflow_http_archive(
@@ -25,39 +25,37 @@ index 54d52e25..14a435e9 100644
  load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 diff --git a/third_party/tensorflow/BUILD b/third_party/tensorflow/BUILD
 new file mode 100644
-index 00000000..e69de29b
+index 0000000..e69de29
 diff --git a/third_party/tensorflow/tensorflow_patches.patch b/third_party/tensorflow/tensorflow_patches.patch
 new file mode 100644
-index 00000000..b4ad792a
+index 0000000..baf9956
 --- /dev/null
 +++ b/third_party/tensorflow/tensorflow_patches.patch
-@@ -0,0 +1,293 @@
-+From f31d6a6ad09757250f88f331003c07034bc7e019 Mon Sep 17 00:00:00 2001
-+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-+Date: Thu, 7 Jan 2021 08:47:01 -0500
-+Subject: [PATCH] TF 2.4 patches
+@@ -0,0 +1,226 @@
++From 6fd5dab2461f2ec595983b91dbf121451c84f756 Mon Sep 17 00:00:00 2001
++From: Jason Furmanek <furmanek@us.ibm.com>
++Date: Tue, 19 Jan 2021 21:03:44 +0000
++Subject: [PATCH] tensorflow_patches_no_memcpy
 +
 +---
-+ .../core/platform/default/build_config/BUILD  |  4 ++
-+ tensorflow/stream_executor/cuda/BUILD         |  2 +-
-+ tensorflow/tensorflow.bzl                     |  4 +-
-+ ...m_google_absl_fix_mac_and_nvcc_build.patch | 45 +++++++++++--------
-+ third_party/gpus/cuda/BUILD.tpl               |  8 ++++
-+ third_party/gpus/cuda_configure.bzl           | 12 +++++
-+ third_party/gpus/find_cuda_config.py          |  2 +
-+ third_party/tensorrt/BUILD.tpl                |  1 +
-+ third_party/tensorrt/tensorrt_configure.bzl   |  2 +
-+ 9 files changed, 60 insertions(+), 20 deletions(-)
++ .../core/platform/default/build_config/BUILD       |  3 ++
++ tensorflow/stream_executor/cuda/BUILD              |  2 +-
++ tensorflow/tensorflow.bzl                          |  4 +-
++ .../com_google_absl_fix_mac_and_nvcc_build.patch   | 45 +++++++++++++---------
++ third_party/gpus/cuda_configure.bzl                |  2 +
++ third_party/gpus/find_cuda_config.py               |  2 +
++ third_party/tensorrt/BUILD.tpl                     |  1 +
++ third_party/tensorrt/tensorrt_configure.bzl        |  1 +
++ 8 files changed, 40 insertions(+), 20 deletions(-)
 +
 +diff --git a/tensorflow/core/platform/default/build_config/BUILD b/tensorflow/core/platform/default/build_config/BUILD
-+index 83eadf2c460..b17542c0fc6 100644
++index 83eadf2..b0e4c89 100644
 +--- a/tensorflow/core/platform/default/build_config/BUILD
 ++++ b/tensorflow/core/platform/default/build_config/BUILD
-+@@ -199,8 +199,12 @@ cc_library(
++@@ -199,8 +199,11 @@ cc_library(
 +             "-Wl,-rpath,../local_config_cuda/cuda/extras/CUPTI/lib",
 +         ],
 +         "//conditions:default": [
-++            "-lmemcpy-2.14",
 ++            "-Lbazel-out/host/bin/external/local_config_cuda/cuda/cuda/lib",
 +             "-Wl,-rpath,../local_config_cuda/cuda/lib64",
 +             "-Wl,-rpath,../local_config_cuda/cuda/extras/CUPTI/lib64",
@@ -67,7 +65,7 @@ index 00000000..b4ad792a
 +     }),
 +     deps = [
 +diff --git a/tensorflow/stream_executor/cuda/BUILD b/tensorflow/stream_executor/cuda/BUILD
-+index 7086217fa8e..9cdd1eedb77 100644
++index 7086217..9cdd1ee 100644
 +--- a/tensorflow/stream_executor/cuda/BUILD
 ++++ b/tensorflow/stream_executor/cuda/BUILD
 +@@ -271,7 +271,7 @@ alias(
@@ -80,7 +78,7 @@ index 00000000..b4ad792a
 +     visibility = ["//visibility:public"],
 + )
 +diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
-+index 096cdd17dcb..a93cc168830 100644
++index 096cdd1..a93cc16 100644
 +--- a/tensorflow/tensorflow.bzl
 ++++ b/tensorflow/tensorflow.bzl
 +@@ -335,7 +335,7 @@ def tf_copts(
@@ -109,7 +107,7 @@ index 00000000..b4ad792a
 +         visibility = [clean_dep("//tensorflow:internal")],
 +         compatible_with = compatible_with,
 +diff --git a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
-+index 6301119ab2c..9a7bd8b4b20 100644
++index 6301119..9a7bd8b 100644
 +--- a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
 ++++ b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
 +@@ -1,7 +1,6 @@
@@ -207,34 +205,8 @@ index 00000000..b4ad792a
 ++ #define CONSTEXPR_D constexpr  // data
 ++ #define CONSTEXPR_F constexpr  // function
 ++ #define CONSTEXPR_M constexpr  // member
-+diff --git a/third_party/gpus/cuda/BUILD.tpl b/third_party/gpus/cuda/BUILD.tpl
-+index 70eacf82883..5cf0e71ccba 100644
-+--- a/third_party/gpus/cuda/BUILD.tpl
-++++ b/third_party/gpus/cuda/BUILD.tpl
-+@@ -171,6 +171,13 @@ cc_library(
-+     linkstatic = 1,
-+ )
-+ 
-++cc_library(
-++    name = "memcpy-2.14",
-++    srcs = ["cuda/lib/%{memcpy-2.14_lib}"],
-++    data = ["cuda/lib/%{memcpy-2.14_lib}"],
-++    linkstatic = 1,
-++)
-++
-+ cc_library(
-+     name = "cuda",
-+     deps = [
-+@@ -181,6 +188,7 @@ cc_library(
-+         ":cudnn",
-+         ":cufft",
-+         ":curand",
-++        ":memcpy-2.14",
-+     ],
-+ )
-+ 
 +diff --git a/third_party/gpus/cuda_configure.bzl b/third_party/gpus/cuda_configure.bzl
-+index 3ba34470b93..f29b2d13e41 100644
++index 3ba3447..3629be1 100644
 +--- a/third_party/gpus/cuda_configure.bzl
 ++++ b/third_party/gpus/cuda_configure.bzl
 +@@ -476,6 +476,8 @@ def _lib_path(lib, cpu_value, basedir, version, static):
@@ -246,46 +218,8 @@ index 00000000..b4ad792a
 +     return version and not static
 + 
 + def _check_cuda_lib_params(lib, cpu_value, basedir, version, static = False):
-+@@ -586,6 +588,13 @@ def _find_libs(repository_ctx, check_cuda_libs_script, cuda_config):
-+             cuda_config.cudnn_version,
-+             static = False,
-+         ),
-++        "memcpy-2.14": _check_cuda_lib_params(
-++            "memcpy-2.14",
-++            cpu_value,
-++            cuda_config.config["cudnn_library_dir"],
-++            "",
-++            static = False,
-++        ),
-+         "cupti": _check_cuda_lib_params(
-+             "cupti",
-+             cpu_value,
-+@@ -794,6 +803,7 @@ def _create_dummy_repository(repository_ctx):
-+             "%{curand_lib}": lib_name("curand", cpu_value),
-+             "%{cupti_lib}": lib_name("cupti", cpu_value),
-+             "%{cusparse_lib}": lib_name("cusparse", cpu_value),
-++            "%{memcpy-2.14_lib}": lib_name("memcpy-2.14", cpu_value),
-+             "%{cub_actual}": ":cuda_headers",
-+             "%{copy_rules}": """
-+ filegroup(name="cuda-include")
-+@@ -826,6 +836,7 @@ filegroup(name="cudnn-include")
-+     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cufft", cpu_value))
-+     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cupti", cpu_value))
-+     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cusparse", cpu_value))
-++    repository_ctx.file("cuda/cuda/lib/%s" % lib_name("memcpy-2.14", cpu_value))
-+
-+     # Set up cuda_config.h, which is used by
-+     # tensorflow/stream_executor/dso_loader.cc.
-+@@ -1165,6 +1176,7 @@ def _create_local_cuda_repository(repository_ctx):
-+             "%{curand_lib}": _basename(repository_ctx, cuda_libs["curand"]),
-+             "%{cupti_lib}": _basename(repository_ctx, cuda_libs["cupti"]),
-+             "%{cusparse_lib}": _basename(repository_ctx, cuda_libs["cusparse"]),
-++            "%{memcpy-2.14_lib}": _basename(repository_ctx, cuda_libs["memcpy-2.14"]),
-+             "%{cub_actual}": cub_actual,
-+             "%{copy_rules}": "\n".join(copy_rules),
-+         },
 +diff --git a/third_party/gpus/find_cuda_config.py b/third_party/gpus/find_cuda_config.py
-+index 80f343023cd..6a85107a65c 100644
++index 80f3430..6a85107 100644
 +--- a/third_party/gpus/find_cuda_config.py
 ++++ b/third_party/gpus/find_cuda_config.py
 +@@ -587,6 +587,8 @@ def find_cuda_config():
@@ -298,7 +232,7 @@ index 00000000..b4ad792a
 +     result.update(
 +         _find_cublas_config(cublas_paths, cublas_version, cuda_version))
 +diff --git a/third_party/tensorrt/BUILD.tpl b/third_party/tensorrt/BUILD.tpl
-+index dfa06ced2ed..0b386f93db4 100644
++index dfa06ce..0b386f9 100644
 +--- a/third_party/tensorrt/BUILD.tpl
 ++++ b/third_party/tensorrt/BUILD.tpl
 +@@ -25,6 +25,7 @@ cc_library(
@@ -310,21 +244,20 @@ index 00000000..b4ad792a
 +     deps = [
 +         ":tensorrt_headers",
 +diff --git a/third_party/tensorrt/tensorrt_configure.bzl b/third_party/tensorrt/tensorrt_configure.bzl
-+index 9c980a92cf8..deafd2a5a8a 100644
++index 9c980a9..fe1830f 100644
 +--- a/third_party/tensorrt/tensorrt_configure.bzl
 ++++ b/third_party/tensorrt/tensorrt_configure.bzl
-+@@ -101,6 +101,8 @@ def _create_local_tensorrt_repository(repository_ctx):
++@@ -101,6 +101,7 @@ def _create_local_tensorrt_repository(repository_ctx):
 + 
 +     # Copy the library and header files.
 +     libraries = [lib_name(lib, cpu_value, trt_version) for lib in _TF_TENSORRT_LIBS]
-++    libraries.append("libmemcpy-2.14.so")
 ++    libraries.append("libmyelin.so.1")
 +     library_dir = config["tensorrt_library_dir"] + "/"
 +     headers = _get_tensorrt_headers(trt_version)
 +     include_dir = config["tensorrt_include_dir"] + "/"
 +-- 
-+2.23.0
++1.8.3.1
 +
 -- 
-2.23.0
+1.8.3.1
 

--- a/tensorflow-serving/0000b-Add-memcpy-wrapper-patch.patch
+++ b/tensorflow-serving/0000b-Add-memcpy-wrapper-patch.patch
@@ -1,0 +1,203 @@
+From 73da0fedced765025dd51146b144bfd4232a8e77 Mon Sep 17 00:00:00 2001
+From: Jason Furmanek <furmanek@us.ibm.com>
+Date: Tue, 19 Jan 2021 21:48:50 +0000
+Subject: [PATCH] Add memcpy wrapper patch
+
+---
+ third_party/tensorflow/tensorflow_patches.patch | 115 +++++++++++++++++++-----
+ 1 file changed, 91 insertions(+), 24 deletions(-)
+
+diff --git a/third_party/tensorflow/tensorflow_patches.patch b/third_party/tensorflow/tensorflow_patches.patch
+index baf9956..ea91185 100644
+--- a/third_party/tensorflow/tensorflow_patches.patch
++++ b/third_party/tensorflow/tensorflow_patches.patch
+@@ -1,27 +1,29 @@
+-From 6fd5dab2461f2ec595983b91dbf121451c84f756 Mon Sep 17 00:00:00 2001
+-From: Jason Furmanek <furmanek@us.ibm.com>
+-Date: Tue, 19 Jan 2021 21:03:44 +0000
+-Subject: [PATCH] tensorflow_patches_no_memcpy
++From f31d6a6ad09757250f88f331003c07034bc7e019 Mon Sep 17 00:00:00 2001
++From: Nishidha Panpaliya <npanpa23@in.ibm.com>
++Date: Thu, 7 Jan 2021 08:47:01 -0500
++Subject: [PATCH] TF 2.4 patches - add memcpy wrapper
+ 
+ ---
+- .../core/platform/default/build_config/BUILD       |  3 ++
+- tensorflow/stream_executor/cuda/BUILD              |  2 +-
+- tensorflow/tensorflow.bzl                          |  4 +-
+- .../com_google_absl_fix_mac_and_nvcc_build.patch   | 45 +++++++++++++---------
+- third_party/gpus/cuda_configure.bzl                |  2 +
+- third_party/gpus/find_cuda_config.py               |  2 +
+- third_party/tensorrt/BUILD.tpl                     |  1 +
+- third_party/tensorrt/tensorrt_configure.bzl        |  1 +
+- 8 files changed, 40 insertions(+), 20 deletions(-)
++ .../core/platform/default/build_config/BUILD  |  4 ++
++ tensorflow/stream_executor/cuda/BUILD         |  2 +-
++ tensorflow/tensorflow.bzl                     |  4 +-
++ ...m_google_absl_fix_mac_and_nvcc_build.patch | 45 +++++++++++--------
++ third_party/gpus/cuda/BUILD.tpl               |  8 ++++
++ third_party/gpus/cuda_configure.bzl           | 12 +++++
++ third_party/gpus/find_cuda_config.py          |  2 +
++ third_party/tensorrt/BUILD.tpl                |  1 +
++ third_party/tensorrt/tensorrt_configure.bzl   |  2 +
++ 9 files changed, 60 insertions(+), 20 deletions(-)
+ 
+ diff --git a/tensorflow/core/platform/default/build_config/BUILD b/tensorflow/core/platform/default/build_config/BUILD
+-index 83eadf2..b0e4c89 100644
++index 83eadf2c460..b17542c0fc6 100644
+ --- a/tensorflow/core/platform/default/build_config/BUILD
+ +++ b/tensorflow/core/platform/default/build_config/BUILD
+-@@ -199,8 +199,11 @@ cc_library(
++@@ -199,8 +199,12 @@ cc_library(
+              "-Wl,-rpath,../local_config_cuda/cuda/extras/CUPTI/lib",
+          ],
+          "//conditions:default": [
+++            "-lmemcpy-2.14",
+ +            "-Lbazel-out/host/bin/external/local_config_cuda/cuda/cuda/lib",
+              "-Wl,-rpath,../local_config_cuda/cuda/lib64",
+              "-Wl,-rpath,../local_config_cuda/cuda/extras/CUPTI/lib64",
+@@ -31,7 +33,7 @@ index 83eadf2..b0e4c89 100644
+      }),
+      deps = [
+ diff --git a/tensorflow/stream_executor/cuda/BUILD b/tensorflow/stream_executor/cuda/BUILD
+-index 7086217..9cdd1ee 100644
++index 7086217fa8e..9cdd1eedb77 100644
+ --- a/tensorflow/stream_executor/cuda/BUILD
+ +++ b/tensorflow/stream_executor/cuda/BUILD
+ @@ -271,7 +271,7 @@ alias(
+@@ -44,7 +46,7 @@ index 7086217..9cdd1ee 100644
+      visibility = ["//visibility:public"],
+  )
+ diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
+-index 096cdd1..a93cc16 100644
++index 096cdd17dcb..a93cc168830 100644
+ --- a/tensorflow/tensorflow.bzl
+ +++ b/tensorflow/tensorflow.bzl
+ @@ -335,7 +335,7 @@ def tf_copts(
+@@ -73,7 +75,7 @@ index 096cdd1..a93cc16 100644
+          visibility = [clean_dep("//tensorflow:internal")],
+          compatible_with = compatible_with,
+ diff --git a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
+-index 6301119..9a7bd8b 100644
++index 6301119ab2c..9a7bd8b4b20 100644
+ --- a/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
+ +++ b/third_party/com_google_absl_fix_mac_and_nvcc_build.patch
+ @@ -1,7 +1,6 @@
+@@ -171,8 +173,34 @@ index 6301119..9a7bd8b 100644
+ + #define CONSTEXPR_D constexpr  // data
+ + #define CONSTEXPR_F constexpr  // function
+ + #define CONSTEXPR_M constexpr  // member
++diff --git a/third_party/gpus/cuda/BUILD.tpl b/third_party/gpus/cuda/BUILD.tpl
++index 70eacf82883..5cf0e71ccba 100644
++--- a/third_party/gpus/cuda/BUILD.tpl
+++++ b/third_party/gpus/cuda/BUILD.tpl
++@@ -171,6 +171,13 @@ cc_library(
++     linkstatic = 1,
++ )
++ 
+++cc_library(
+++    name = "memcpy-2.14",
+++    srcs = ["cuda/lib/%{memcpy-2.14_lib}"],
+++    data = ["cuda/lib/%{memcpy-2.14_lib}"],
+++    linkstatic = 1,
+++)
+++
++ cc_library(
++     name = "cuda",
++     deps = [
++@@ -181,6 +188,7 @@ cc_library(
++         ":cudnn",
++         ":cufft",
++         ":curand",
+++        ":memcpy-2.14",
++     ],
++ )
++ 
+ diff --git a/third_party/gpus/cuda_configure.bzl b/third_party/gpus/cuda_configure.bzl
+-index 3ba3447..3629be1 100644
++index 3ba34470b93..f29b2d13e41 100644
+ --- a/third_party/gpus/cuda_configure.bzl
+ +++ b/third_party/gpus/cuda_configure.bzl
+ @@ -476,6 +476,8 @@ def _lib_path(lib, cpu_value, basedir, version, static):
+@@ -184,8 +212,46 @@ index 3ba3447..3629be1 100644
+      return version and not static
+  
+  def _check_cuda_lib_params(lib, cpu_value, basedir, version, static = False):
++@@ -586,6 +588,13 @@ def _find_libs(repository_ctx, check_cuda_libs_script, cuda_config):
++             cuda_config.cudnn_version,
++             static = False,
++         ),
+++        "memcpy-2.14": _check_cuda_lib_params(
+++            "memcpy-2.14",
+++            cpu_value,
+++            cuda_config.config["cudnn_library_dir"],
+++            "",
+++            static = False,
+++        ),
++         "cupti": _check_cuda_lib_params(
++             "cupti",
++             cpu_value,
++@@ -794,6 +803,7 @@ def _create_dummy_repository(repository_ctx):
++             "%{curand_lib}": lib_name("curand", cpu_value),
++             "%{cupti_lib}": lib_name("cupti", cpu_value),
++             "%{cusparse_lib}": lib_name("cusparse", cpu_value),
+++            "%{memcpy-2.14_lib}": lib_name("memcpy-2.14", cpu_value),
++             "%{cub_actual}": ":cuda_headers",
++             "%{copy_rules}": """
++ filegroup(name="cuda-include")
++@@ -826,6 +836,7 @@ filegroup(name="cudnn-include")
++     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cufft", cpu_value))
++     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cupti", cpu_value))
++     repository_ctx.file("cuda/cuda/lib/%s" % lib_name("cusparse", cpu_value))
+++    repository_ctx.file("cuda/cuda/lib/%s" % lib_name("memcpy-2.14", cpu_value))
++
++     # Set up cuda_config.h, which is used by
++     # tensorflow/stream_executor/dso_loader.cc.
++@@ -1165,6 +1176,7 @@ def _create_local_cuda_repository(repository_ctx):
++             "%{curand_lib}": _basename(repository_ctx, cuda_libs["curand"]),
++             "%{cupti_lib}": _basename(repository_ctx, cuda_libs["cupti"]),
++             "%{cusparse_lib}": _basename(repository_ctx, cuda_libs["cusparse"]),
+++            "%{memcpy-2.14_lib}": _basename(repository_ctx, cuda_libs["memcpy-2.14"]),
++             "%{cub_actual}": cub_actual,
++             "%{copy_rules}": "\n".join(copy_rules),
++         },
+ diff --git a/third_party/gpus/find_cuda_config.py b/third_party/gpus/find_cuda_config.py
+-index 80f3430..6a85107 100644
++index 80f343023cd..6a85107a65c 100644
+ --- a/third_party/gpus/find_cuda_config.py
+ +++ b/third_party/gpus/find_cuda_config.py
+ @@ -587,6 +587,8 @@ def find_cuda_config():
+@@ -198,7 +264,7 @@ index 80f3430..6a85107 100644
+      result.update(
+          _find_cublas_config(cublas_paths, cublas_version, cuda_version))
+ diff --git a/third_party/tensorrt/BUILD.tpl b/third_party/tensorrt/BUILD.tpl
+-index dfa06ce..0b386f9 100644
++index dfa06ced2ed..0b386f93db4 100644
+ --- a/third_party/tensorrt/BUILD.tpl
+ +++ b/third_party/tensorrt/BUILD.tpl
+ @@ -25,6 +25,7 @@ cc_library(
+@@ -210,17 +276,18 @@ index dfa06ce..0b386f9 100644
+      deps = [
+          ":tensorrt_headers",
+ diff --git a/third_party/tensorrt/tensorrt_configure.bzl b/third_party/tensorrt/tensorrt_configure.bzl
+-index 9c980a9..fe1830f 100644
++index 9c980a92cf8..deafd2a5a8a 100644
+ --- a/third_party/tensorrt/tensorrt_configure.bzl
+ +++ b/third_party/tensorrt/tensorrt_configure.bzl
+-@@ -101,6 +101,7 @@ def _create_local_tensorrt_repository(repository_ctx):
++@@ -101,6 +101,8 @@ def _create_local_tensorrt_repository(repository_ctx):
+  
+      # Copy the library and header files.
+      libraries = [lib_name(lib, cpu_value, trt_version) for lib in _TF_TENSORRT_LIBS]
+++    libraries.append("libmemcpy-2.14.so")
+ +    libraries.append("libmyelin.so.1")
+      library_dir = config["tensorrt_library_dir"] + "/"
+      headers = _get_tensorrt_headers(trt_version)
+      include_dir = config["tensorrt_include_dir"] + "/"
+ -- 
+-1.8.3.1
++2.23.0
+ 
+-- 
+1.8.3.1
+

--- a/tensorflow-serving/build.sh
+++ b/tensorflow-serving/build.sh
@@ -29,10 +29,10 @@ then
   # Pick up the CUDA and CUDNN environment
   $SCRIPT_DIR/set_tf_serving_nvidia_bazelrc.sh $SRC_DIR/tensorflow_serving $PY_VER
 
-  if [[ "${ARCH}" == 'x86_64' ]] && [[ $PY_VER < 3.8 ]]; then
+  if [[ "${ARCH}" == 'x86_64' ]] && [[ $PY_VER < 3.8 || $cudatoolkit == "11.0" ]]; then
     # Create symlink of libmemcpy-2.14.so from where it can be picked up by TF build
     # Avoid this for Python3.8 since this is related to TensorRT and TensorRT is
-    # not available for Py38 yet.
+    # not available for Py38 yet. This is always needed for cuda 11.0 because cudnn8 needs it as well.
     ln -s ${PREFIX}/lib/libmemcpy-2.14.so ${PREFIX}/lib64/libmemcpy-2.14.so
   fi
 fi

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -8,7 +8,8 @@ source:
    git_url: https://github.com/tensorflow/serving.git
    git_rev: {{ version }}
    patches:
-     - 0000-tensorflow_patches.patch         # [x86_64]
+     - 0000a-tensorflow_patches.patch        # [x86_64]
+     - 0000b-Add-memcpy-wrapper-patch.patch  # [x86_64 and build_type == 'cuda' and py<38]
      - 0001-TF-Build-fix-ppc64le.patch       # [ppc64le]
  
 build:

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -13,7 +13,7 @@ source:
      - 0001-TF-Build-fix-ppc64le.patch       # [ppc64le]
  
 build:
-  number: 3
+  number: 4
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} # [build_type == 'cpu'] 
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} # [build_type == 'cuda']
 {% if build_type == 'cuda' %}

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -9,7 +9,7 @@ source:
    git_rev: {{ version }}
    patches:
      - 0000a-tensorflow_patches.patch        # [x86_64]
-     - 0000b-Add-memcpy-wrapper-patch.patch  # [x86_64 and build_type == 'cuda' and py<38]
+     - 0000b-Add-memcpy-wrapper-patch.patch  # [x86_64 and build_type == 'cuda' and ((cudatoolkit=='10.2' and py<38) or (cudatoolkit=='11.0'))]
      - 0001-TF-Build-fix-ppc64le.patch       # [ppc64le]
  
 build:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #17 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.


OK, this is complicated:
We include a patch to add some patches for Tensorflow into the Tensorflow Serving code base. Serving pulls in and builds Tensorflow code in its `third_party` directory and we need to patch it for a few issues. One of those issues is the TensorRT issue where it is built against a newer glibc than is included in the Anaconda toolchain resulting in memcpy symbol mismatches. We work around this issue by a symbol mapping wrapper library (`libmempy-2.14`). There are other patches as well and they were all blobbed together into one to make the patch of a patch process easier.
Unfortunately however, the memcpy wrapper patch, which is needed when we build Cuda-enabled is not needed for py38 because TRT is currently not in supported in py38. In addition, we moved the symbol mapping wrapper library to it's own separate package for cuda11. In TRT7.0 which is for cuda10.2, the wrapper is built in to the TRT package. So while we need the wrapper for cuda10.2, we don't need to add the build time dependency for the separate wrapper package.

Also, this is all only for x86. Anaconda uses a RH7 based glibc in their toolchain on ppc64le, so no memcpy issues are present there with TensorRT.

Got all that?

So this PR splits the patch of a x86-only patch blob into two: `0000a` and `0000b`. The `a` is still a blob of things needed always. The `b` patch adds in the memcpy linker patch, which is needed when building for Cuda, on py36 and py37.

Edit: Also when building with cuda11.0, the memcpy wrapper is always needed because cudnn8 has the same problem. So the `b` patch should always be included when building for cuda11.0.