### PR TITLE
protobuf pin adjustment

### DIFF
--- a/tensorflow-serving-api/meta.yaml
+++ b/tensorflow-serving-api/meta.yaml
@@ -23,11 +23,11 @@ requirements:
    - python # noarch package; don't tie to specific python version
    - numpy {{ numpy }}
    - grpcio {{ grpcio }}
-   - protobuf {{ protobuf }}
+   - protobuf 3.9 # currently tf-serving only works with pb 3.9
   run:
    - python # noarch package; don't tie to specific python version
    - grpcio {{ grpcio }}
-   - protobuf {{ protobuf }}
+   - protobuf 3.9 # currently tf-serving only works with pb 3.9
 
 about:
   home: https://www.tensorflow.org/tfx/guide/serving

--- a/tensorflow-serving-api/meta.yaml
+++ b/tensorflow-serving-api/meta.yaml
@@ -11,7 +11,7 @@ source:
      - 0001-Replace-k8-with-ppc-for-Power-builds.patch # [ppc64le]
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 requirements:

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -44,7 +44,7 @@ requirements:
   run:
    - libevent {{ libevent }}
    - grpcio {{ grpcio }}
-   - protobuf {{ protobuf }}
+   - protobuf 3.9                    # currently tf-serving only works with pb 3.9
    - cudatoolkit {{ cudatoolkit }}   # [build_type == 'cuda']
    - cudnn {{ cudnn }}               # [build_type == 'cuda']
    - nccl {{ nccl }}                 # [build_type == 'cuda']

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -13,7 +13,7 @@ source:
      - 0001-TF-Build-fix-ppc64le.patch       # [ppc64le]
  
 build:
-  number: 1
+  number: 2
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} # [build_type == 'cpu'] 
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} # [build_type == 'cuda']
 {% if build_type == 'cuda' %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Open-CE 1.2 is moving the protobuf pin up to 3.11, but Serving only works with 3.9.
Serving is also being moved to its own open-ce env file in: https://github.com/open-ce/open-ce/pull/381

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
