### PR TITLE
[1.1,1.2] Remove libgcc runtime pins

### DIFF
--- a/tensorflow-serving-api/meta.yaml
+++ b/tensorflow-serving-api/meta.yaml
@@ -11,12 +11,9 @@ source:
      - 0001-Replace-k8-with-ppc-for-Power-builds.patch # [ppc64le]
 
 build:
-  number: 5
+  number: 6
   string: py_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   noarch: python
-  ignore_run_exports:
-    - libgcc-ng
-    - libstdcxx-ng
 
 requirements:
   build:
@@ -38,9 +35,6 @@ requirements:
    - python # noarch package; don't tie to specific python version
    - grpcio {{ grpcio }}
    - protobuf 3.9 # currently tf-serving only works with pb 3.9
-   # Use pins to control cos6/cos7 match
-   - libgcc-ng  {{ libgcc }}
-   - libstdcxx-ng  {{ libstdcxx }}
 
 about:
   home: https://www.tensorflow.org/tfx/guide/serving

--- a/tensorflow-serving/meta.yaml
+++ b/tensorflow-serving/meta.yaml
@@ -13,16 +13,13 @@ source:
      - 0001-TF-Build-fix-ppc64le.patch       # [ppc64le]
  
 build:
-  number: 5
+  number: 6
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} # [build_type == 'cpu'] 
   string: h{{ PKG_HASH }}_{{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} # [build_type == 'cuda']
 {% if build_type == 'cuda' %}
   script_env:
     - CUDA_HOME
 {% endif %}
-  ignore_run_exports:
-    - libgcc-ng
-    - libstdcxx-ng
 
 requirements:
   build:
@@ -58,9 +55,6 @@ requirements:
    - nccl {{ nccl }}                 # [build_type == 'cuda']
    - tensorrt {{ tensorrt }}         # [build_type == 'cuda' and py<38]
    - libmemcpy_wrapper                 # [x86_64 and build_type == 'cuda' and cudatoolkit=='11.0']
-   # Use pins to control cos6/cos7 match
-   - libgcc-ng  {{ libgcc }}
-   - libstdcxx-ng  {{ libstdcxx }}
 
 about:
   home: https://www.tensorflow.org/tfx/guide/serving


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any tests to validate this change?

## Description

Adjust libgcc and libstdc++ runtime dependencies for xgboost

open-ce/open-ce#452

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
